### PR TITLE
fix: Fix ModelOutput subclass by adding dataclass decorator

### DIFF
--- a/src/transformer_embeddings/model.py
+++ b/src/transformer_embeddings/model.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
 from shutil import copy2
@@ -32,6 +33,7 @@ DEVICE = DEVICE_CUDA if cuda.is_available() else DEVICE_CPU
 TransformerInputOutput = Union[BatchEncoding, ModelOutput]
 
 
+@dataclass
 class TransformerEmbeddingsOutput(ModelOutput):
     output: Optional[ModelOutput] = None
     input: Optional[BatchEncoding] = None


### PR DESCRIPTION
## Description
The newest transformers version[ introduced a change](https://github.com/huggingface/transformers/commit/d7bd325b5a44054341acc536339adab9ef8e8bb2) in version 4.34.0 that broke the TransformerEmbeddingsOutput since it fails if anything that subclasses ModelOutput doesn't have the dataclass decorator. This broke semantic sampling, which depends on transformer embeddings. Fixing here. Will add a test in a follow up.


## Tests

- [ ] Local.
- [ ] CI.
